### PR TITLE
[codex] Upgrade Dart dependencies

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -24,8 +24,10 @@ analyzer:
 
 linter:
   rules:
+    always_use_package_imports: false
     prefer_const_constructors_in_immutables: true
     prefer_relative_imports: true
+    unreachable_from_main: false
     prefer_final_locals: true
     avoid_void_async: true
     unnecessary_await_in_return: true
@@ -57,4 +59,3 @@ linter:
     flutter_style_todos: false
     document_ignores: false
     specify_nonobvious_property_types: false
-

--- a/lib/src/fingerprint/numeric_fingerprint_generator.dart
+++ b/lib/src/fingerprint/numeric_fingerprint_generator.dart
@@ -70,7 +70,7 @@ class NumericFingerprintGenerator implements FingerprintGenerator {
     final sortedIdentityKeys = [...identityKeys]..sort(identityKeyComparator);
 
     final keys = <int>[];
-    sortedIdentityKeys.forEach((IdentityKey key) {
+    sortedIdentityKeys.forEach((key) {
       final publicKeyBytes = key.publicKey.serialize();
       keys.addAll(publicKeyBytes.toList());
     });

--- a/lib/src/state/fingerprint_protocol.pb.dart
+++ b/lib/src/state/fingerprint_protocol.pb.dart
@@ -62,9 +62,6 @@ class LogicalFingerprint extends $pb.GeneratedMessage {
   @override
   LogicalFingerprint createEmptyInstance() => create();
 
-  static $pb.PbList<LogicalFingerprint> createRepeated() =>
-      $pb.PbList<LogicalFingerprint>();
-
   @$core.pragma('dart2js:noInline')
   static LogicalFingerprint getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<LogicalFingerprint>(create);
@@ -166,9 +163,6 @@ class CombinedFingerprints extends $pb.GeneratedMessage {
 
   @override
   CombinedFingerprints createEmptyInstance() => create();
-
-  static $pb.PbList<CombinedFingerprints> createRepeated() =>
-      $pb.PbList<CombinedFingerprints>();
 
   @$core.pragma('dart2js:noInline')
   static CombinedFingerprints getDefault() => _defaultInstance ??=

--- a/lib/src/state/local_storage_protocol.pb.dart
+++ b/lib/src/state/local_storage_protocol.pb.dart
@@ -80,9 +80,6 @@ class SessionStructureChainChainKey extends $pb.GeneratedMessage {
   @override
   SessionStructureChainChainKey createEmptyInstance() => create();
 
-  static $pb.PbList<SessionStructureChainChainKey> createRepeated() =>
-      $pb.PbList<SessionStructureChainChainKey>();
-
   @$core.pragma('dart2js:noInline')
   static SessionStructureChainChainKey getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<SessionStructureChainChainKey>(create);
@@ -213,9 +210,6 @@ class SessionStructureChainMessageKey extends $pb.GeneratedMessage {
 
   @override
   SessionStructureChainMessageKey createEmptyInstance() => create();
-
-  static $pb.PbList<SessionStructureChainMessageKey> createRepeated() =>
-      $pb.PbList<SessionStructureChainMessageKey>();
 
   @$core.pragma('dart2js:noInline')
   static SessionStructureChainMessageKey getDefault() => _defaultInstance ??=
@@ -377,9 +371,6 @@ class SessionStructureChain extends $pb.GeneratedMessage {
 
   @override
   SessionStructureChain createEmptyInstance() => create();
-
-  static $pb.PbList<SessionStructureChain> createRepeated() =>
-      $pb.PbList<SessionStructureChain>();
 
   @$core.pragma('dart2js:noInline')
   static SessionStructureChain getDefault() => _defaultInstance ??=
@@ -564,9 +555,6 @@ class SessionStructurePendingKeyExchange extends $pb.GeneratedMessage {
 
   @override
   SessionStructurePendingKeyExchange createEmptyInstance() => create();
-
-  static $pb.PbList<SessionStructurePendingKeyExchange> createRepeated() =>
-      $pb.PbList<SessionStructurePendingKeyExchange>();
 
   @$core.pragma('dart2js:noInline')
   static SessionStructurePendingKeyExchange getDefault() => _defaultInstance ??=
@@ -759,9 +747,6 @@ class SessionStructurePendingPreKey extends $pb.GeneratedMessage {
 
   @override
   SessionStructurePendingPreKey createEmptyInstance() => create();
-
-  static $pb.PbList<SessionStructurePendingPreKey> createRepeated() =>
-      $pb.PbList<SessionStructurePendingPreKey>();
 
   @$core.pragma('dart2js:noInline')
   static SessionStructurePendingPreKey getDefault() => _defaultInstance ??=
@@ -1003,9 +988,6 @@ class SessionStructure extends $pb.GeneratedMessage {
 
   @override
   SessionStructure createEmptyInstance() => create();
-
-  static $pb.PbList<SessionStructure> createRepeated() =>
-      $pb.PbList<SessionStructure>();
 
   @$core.pragma('dart2js:noInline')
   static SessionStructure getDefault() => _defaultInstance ??=
@@ -1266,9 +1248,6 @@ class RecordStructure extends $pb.GeneratedMessage {
   @override
   RecordStructure createEmptyInstance() => create();
 
-  static $pb.PbList<RecordStructure> createRepeated() =>
-      $pb.PbList<RecordStructure>();
-
   @$core.pragma('dart2js:noInline')
   static RecordStructure getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<RecordStructure>(create);
@@ -1378,9 +1357,6 @@ class PreKeyRecordStructure extends $pb.GeneratedMessage {
 
   @override
   PreKeyRecordStructure createEmptyInstance() => create();
-
-  static $pb.PbList<PreKeyRecordStructure> createRepeated() =>
-      $pb.PbList<PreKeyRecordStructure>();
 
   @$core.pragma('dart2js:noInline')
   static PreKeyRecordStructure getDefault() => _defaultInstance ??=
@@ -1537,9 +1513,6 @@ class SignedPreKeyRecordStructure extends $pb.GeneratedMessage {
   @override
   SignedPreKeyRecordStructure createEmptyInstance() => create();
 
-  static $pb.PbList<SignedPreKeyRecordStructure> createRepeated() =>
-      $pb.PbList<SignedPreKeyRecordStructure>();
-
   @$core.pragma('dart2js:noInline')
   static SignedPreKeyRecordStructure getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<SignedPreKeyRecordStructure>(create);
@@ -1690,9 +1663,6 @@ class IdentityKeyPairStructure extends $pb.GeneratedMessage {
   @override
   IdentityKeyPairStructure createEmptyInstance() => create();
 
-  static $pb.PbList<IdentityKeyPairStructure> createRepeated() =>
-      $pb.PbList<IdentityKeyPairStructure>();
-
   @$core.pragma('dart2js:noInline')
   static IdentityKeyPairStructure getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<IdentityKeyPairStructure>(create);
@@ -1801,9 +1771,6 @@ class SenderKeyStateStructureSenderChainKey extends $pb.GeneratedMessage {
 
   @override
   SenderKeyStateStructureSenderChainKey createEmptyInstance() => create();
-
-  static $pb.PbList<SenderKeyStateStructureSenderChainKey> createRepeated() =>
-      $pb.PbList<SenderKeyStateStructureSenderChainKey>();
 
   @$core.pragma('dart2js:noInline')
   static SenderKeyStateStructureSenderChainKey getDefault() =>
@@ -1915,9 +1882,6 @@ class SenderKeyStateStructureSenderMessageKey extends $pb.GeneratedMessage {
   @override
   SenderKeyStateStructureSenderMessageKey createEmptyInstance() => create();
 
-  static $pb.PbList<SenderKeyStateStructureSenderMessageKey> createRepeated() =>
-      $pb.PbList<SenderKeyStateStructureSenderMessageKey>();
-
   @$core.pragma('dart2js:noInline')
   static SenderKeyStateStructureSenderMessageKey getDefault() =>
       _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<
@@ -2026,9 +1990,6 @@ class SenderKeyStateStructureSenderSigningKey extends $pb.GeneratedMessage {
 
   @override
   SenderKeyStateStructureSenderSigningKey createEmptyInstance() => create();
-
-  static $pb.PbList<SenderKeyStateStructureSenderSigningKey> createRepeated() =>
-      $pb.PbList<SenderKeyStateStructureSenderSigningKey>();
 
   @$core.pragma('dart2js:noInline')
   static SenderKeyStateStructureSenderSigningKey getDefault() =>
@@ -2162,9 +2123,6 @@ class SenderKeyStateStructure extends $pb.GeneratedMessage {
   @override
   SenderKeyStateStructure createEmptyInstance() => create();
 
-  static $pb.PbList<SenderKeyStateStructure> createRepeated() =>
-      $pb.PbList<SenderKeyStateStructure>();
-
   @$core.pragma('dart2js:noInline')
   static SenderKeyStateStructure getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<SenderKeyStateStructure>(create);
@@ -2287,9 +2245,6 @@ class SenderKeyRecordStructure extends $pb.GeneratedMessage {
 
   @override
   SenderKeyRecordStructure createEmptyInstance() => create();
-
-  static $pb.PbList<SenderKeyRecordStructure> createRepeated() =>
-      $pb.PbList<SenderKeyRecordStructure>();
 
   @$core.pragma('dart2js:noInline')
   static SenderKeyRecordStructure getDefault() => _defaultInstance ??=

--- a/lib/src/state/whisper_text_protocol.pb.dart
+++ b/lib/src/state/whisper_text_protocol.pb.dart
@@ -95,9 +95,6 @@ class SignalMessage extends $pb.GeneratedMessage {
   @override
   SignalMessage createEmptyInstance() => create();
 
-  static $pb.PbList<SignalMessage> createRepeated() =>
-      $pb.PbList<SignalMessage>();
-
   @$core.pragma('dart2js:noInline')
   static SignalMessage getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<SignalMessage>(create);
@@ -274,9 +271,6 @@ class PreKeySignalMessage extends $pb.GeneratedMessage {
 
   @override
   PreKeySignalMessage createEmptyInstance() => create();
-
-  static $pb.PbList<PreKeySignalMessage> createRepeated() =>
-      $pb.PbList<PreKeySignalMessage>();
 
   @$core.pragma('dart2js:noInline')
   static PreKeySignalMessage getDefault() => _defaultInstance ??=
@@ -473,9 +467,6 @@ class KeyExchangeMessage extends $pb.GeneratedMessage {
   @override
   KeyExchangeMessage createEmptyInstance() => create();
 
-  static $pb.PbList<KeyExchangeMessage> createRepeated() =>
-      $pb.PbList<KeyExchangeMessage>();
-
   @$core.pragma('dart2js:noInline')
   static KeyExchangeMessage getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<KeyExchangeMessage>(create);
@@ -632,9 +623,6 @@ class SenderKeyMessage extends $pb.GeneratedMessage {
   @override
   SenderKeyMessage createEmptyInstance() => create();
 
-  static $pb.PbList<SenderKeyMessage> createRepeated() =>
-      $pb.PbList<SenderKeyMessage>();
-
   @$core.pragma('dart2js:noInline')
   static SenderKeyMessage getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<SenderKeyMessage>(create);
@@ -779,9 +767,6 @@ class SenderKeyDistributionMessage extends $pb.GeneratedMessage {
   @override
   SenderKeyDistributionMessage createEmptyInstance() => create();
 
-  static $pb.PbList<SenderKeyDistributionMessage> createRepeated() =>
-      $pb.PbList<SenderKeyDistributionMessage>();
-
   @$core.pragma('dart2js:noInline')
   static SenderKeyDistributionMessage getDefault() => _defaultInstance ??=
       $pb.GeneratedMessage.$_defaultFor<SenderKeyDistributionMessage>(create);
@@ -917,9 +902,6 @@ class DeviceConsistencyCodeMessage extends $pb.GeneratedMessage {
 
   @override
   DeviceConsistencyCodeMessage createEmptyInstance() => create();
-
-  static $pb.PbList<DeviceConsistencyCodeMessage> createRepeated() =>
-      $pb.PbList<DeviceConsistencyCodeMessage>();
 
   @$core.pragma('dart2js:noInline')
   static DeviceConsistencyCodeMessage getDefault() => _defaultInstance ??=

--- a/lib/src/util/byte_util.dart
+++ b/lib/src/util/byte_util.dart
@@ -72,7 +72,6 @@ class ByteUtil {
   }
 
   static int compare(Uint8List left, Uint8List right) {
-    // ignore: parameter_assignments, avoid_multiple_declarations_per_line
     for (var i = 0, j = 0; i < left.length && j < right.length; i++, j++) {
       final a = left[i] & 0xff;
       final b = right[j] & 0xff;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,10 +19,10 @@ dependencies:
   meta: ^1.16.0
   optional: ^6.1.0+1
   pointycastle: ^4.0.0
-  protobuf: ^4.0.0
+  protobuf: ^6.0.0
   x25519: ^0.1.1
 
 
 dev_dependencies:
   test: ^1.25.8
-  very_good_analysis: ^8.0.0
+  very_good_analysis: ^10.2.0


### PR DESCRIPTION
## Summary

- Upgrade `protobuf` to `^6.0.0` and `very_good_analysis` to `^10.2.0`.
- Remove obsolete generated protobuf `createRepeated()` helpers that call the removed `PbList()` constructor.
- Adjust analysis options and minor lint findings for the newer analysis rules.

## Why

`dart pub outdated` reported constrained direct dependencies. Moving to the current resolvable versions exposed an incompatibility in older generated protobuf output, where static repeated-list helpers still called `$pb.PbList()` directly. Those helpers are not needed by the runtime path and are no longer emitted by newer generators.

## Validation

- `dart pub outdated` -> `Found no outdated packages`
- `dart analyze` -> `No issues found!`
- `dart test` -> `All tests passed!`