### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -4,6 +4,8 @@
 # documentation.
 
 name: Dart
+permissions:
+  contents: read
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Potential fix for [https://github.com/MixinNetwork/libsignal_protocol_dart/security/code-scanning/1](https://github.com/MixinNetwork/libsignal_protocol_dart/security/code-scanning/1)

To resolve this issue, you should explicitly specify a `permissions` block at the workflow level (top-level, before `jobs:`) within `.github/workflows/dart.yml`. This will restrict the default permissions granted to the `GITHUB_TOKEN` to just what is needed. For the provided workflow, the necessary permission is at least `contents: read`, since the workflow uses `actions/checkout` to read the repository's source, and does not require any write permissions (e.g., on contents, issues, or pull requests).  
Add the following block just beneath the `name:` declaration, above the `on:` section:

```yaml
permissions:
  contents: read
```

No additional imports or dependencies are necessary.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
